### PR TITLE
Dependencies one-place config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: android
 
 android:
   components:
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
 
     - extra-google-m2repository
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 
 android:
   components:
-    - build-tools-28.0.3
+    - build-tools-28.0.2
     - android-28
 
     - extra-google-m2repository

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ The project is a straightforward Github API client containing 3 screens (user se
 * repository - repository detail
 * base - module containing a code shared between all modules
 
-![Project structue](https://raw.githubusercontent.com/frogermcs/MultiModuleGithubClient/master/docs/img/app_diagram.png "Project structure")
+![Project structure](https://raw.githubusercontent.com/frogermcs/MultiModuleGithubClient/master/docs/img/app_diagram.png "Project structure")
 
+### Dependencies management
+It is easy to get lost with dependencies management across different project modules (especially with libs versions). To make it easier, take a look at `buildsystem/dependencies.gradle` where everything is configured. Each module has separate configuration, with additional two for testing and annotation processing. Like some other patterns, this was originally introduced in [Azimo](https://azimo.com) Android application by [@dbarwacz](https://github.com/dbarwacz).
 
 ## Dagger 2
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,12 +21,13 @@ dependencies {
     implementation project(':features:base')
     implementation project(':features:repositories')
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
-    annotationProcessor 'com.google.auto.factory:auto-factory:1.0-beta3'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-SNAPSHOT'
-
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
+    rootProject.app.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.unitTestsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.annotationProcessorsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-beta02'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'org.jacoco:org.jacoco.core:0.8.1'
         classpath 'com.jakewharton:butterknife-gradle-plugin:9.0.0-SNAPSHOT'
     }
@@ -20,3 +20,5 @@ allprojects {
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     }
 }
+
+apply from: 'buildsystem/dependencies.gradle'

--- a/buildsystem/android_commons.gradle
+++ b/buildsystem/android_commons.gradle
@@ -1,8 +1,8 @@
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/buildsystem/dependencies.gradle
+++ b/buildsystem/dependencies.gradle
@@ -1,0 +1,104 @@
+ext {
+    //
+    // ===== Versions =====
+    //
+
+    //Annotation processor dependencies
+    daggerVersion = '2.14.1'
+    autoFactoryVersion = '1.0-beta3'
+    butterknifeVersion = '9.0.0-SNAPSHOT'
+
+    //Standard dependencies
+    supportLibraryVersion = '28.0.0'
+    javaxAnnotationsVersion = '10.0-b28'
+    autoFactoryVersion = '1.0-beta3'
+    rxAndroidVersion = '1.2.1'
+    rxJavaVersion = '1.3.2'
+    rxBindingVersion = '1.0.1'
+    timberVersion = '4.5.1'
+    retrofitVersion = '2.3.0'
+    gsonVersion = '2.3.0'
+    okhttpVersion = '3.10.0'
+    guavaVersion = '26.0-android'
+
+    // Testing dependencies
+    junitVersion = '4.12'
+    mockitoVersion = '2.21.0'
+
+    //
+    // ===== Libraries =====
+    //
+
+    //Annotation processor dependencies
+    daggerCompiler = "com.google.dagger:dagger-compiler:${daggerVersion}"
+    autoFactoryCompiler = "com.google.auto.factory:auto-factory:${autoFactoryVersion}"
+    butterknifeCompiler = "com.jakewharton:butterknife-compiler:${butterknifeVersion}"
+
+    //Standard dependencies
+    appCompatV7 = "com.android.support:appcompat-v7:${supportLibraryVersion}"
+    recyclerViewV7 = "com.android.support:recyclerview-v7:${supportLibraryVersion}"
+
+    butterknife = "com.jakewharton:butterknife:${butterknifeVersion}"
+    dagger = "com.google.dagger:dagger:${daggerVersion}"
+    javaxAnnotations = "org.glassfish:javax.annotation:${javaxAnnotationsVersion}"
+    autoFactory = "com.google.auto.factory:auto-factory:${autoFactoryVersion}"
+    rxAndroid = "io.reactivex:rxandroid:${rxAndroidVersion}"
+    rxJava = "io.reactivex:rxjava:${rxJavaVersion}"
+    rxBinding = "com.jakewharton.rxbinding:rxbinding:${rxBindingVersion}"
+    timber = "com.jakewharton.timber:timber:${timberVersion}"
+    retrofit = "com.squareup.retrofit2:retrofit:${retrofitVersion}"
+    retrofitRxAdapter = "com.squareup.retrofit2:adapter-rxjava:${retrofitVersion}"
+    retrofitGsonConverter = "com.squareup.retrofit2:converter-gson:${gsonVersion}"
+    okhttp = "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+    okhttpLoggingInterceptor = "com.squareup.okhttp3:logging-interceptor:${okhttpVersion}"
+    guavaAndroid = "com.google.guava:guava:${guavaVersion}"
+
+    //Testing dependencies
+    junit = "junit:junit:${junitVersion}"
+    mockito = "org.mockito:mockito-core:${mockitoVersion}"
+
+    //
+    // ===== Modules =====
+    //
+    app = [
+            [configuration: "implementation", dependency: appCompatV7],
+    ]
+
+    repository = [
+    ]
+
+    repos = [
+            [configuration: "implementation", dependency: recyclerViewV7],
+    ]
+
+    base = [
+            [configuration: "api", dependency: butterknife],
+            [configuration: "api", dependency: appCompatV7],
+            [configuration: "api", dependency: dagger],
+            [configuration: "api", dependency: javaxAnnotations],
+            [configuration: "api", dependency: autoFactory],
+            [configuration: "api", dependency: rxAndroid],
+            [configuration: "api", dependency: rxJava],
+            [configuration: "api", dependency: rxBinding],
+            [configuration: "api", dependency: timber],
+            [configuration: "api", dependency: retrofit],
+            [configuration: "api", dependency: retrofitRxAdapter],
+            [configuration: "api", dependency: retrofitGsonConverter],
+            [configuration: "api", dependency: okhttp],
+            [configuration: "api", dependency: okhttpLoggingInterceptor],
+            [configuration: "api", dependency: guavaAndroid],
+    ]
+
+    //Imported in all modules
+    unitTestsDependencies = [
+            [configuration: "testImplementation", dependency: junit],
+            [configuration: "testImplementation", dependency: mockito]
+    ]
+
+    //Imported in all modules
+    annotationProcessorsDependencies = [
+            [configuration: "annotationProcessor", dependency: autoFactoryCompiler],
+            [configuration: "annotationProcessor", dependency: daggerCompiler],
+            [configuration: "annotationProcessor", dependency: butterknifeCompiler],
+    ]
+}

--- a/features/base/build.gradle
+++ b/features/base/build.gradle
@@ -12,30 +12,14 @@ dependencies {
     feature project(":features:repositories")
     feature project(":features:repository")
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-SNAPSHOT'
-    annotationProcessor 'com.google.auto.factory:auto-factory:1.0-beta3'
+    rootProject.base.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.unitTestsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.annotationProcessorsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
 
-    api 'com.jakewharton:butterknife:9.0.0-SNAPSHOT'
-    api 'com.android.support:appcompat-v7:27.1.1'
-
-    api 'com.google.dagger:dagger:2.14.1'
-    api 'org.glassfish:javax.annotation:10.0-b28'
-    api 'com.google.auto.factory:auto-factory:1.0-beta3'
-
-    api 'io.reactivex:rxandroid:1.2.1'
-    api 'io.reactivex:rxjava:1.3.2'
-    api 'com.jakewharton.rxbinding:rxbinding:1.0.1'
-    api 'com.jakewharton.timber:timber:4.5.1'
-
-    api 'com.squareup.retrofit2:retrofit:2.3.0'
-    api 'com.squareup.retrofit2:adapter-rxjava:2.3.0'
-    api 'com.squareup.retrofit2:converter-gson:2.3.0'
-    api 'com.squareup.okhttp3:okhttp:3.8.1'
-    api 'com.squareup.okhttp3:logging-interceptor:3.8.1'
-
-    api 'com.google.guava:guava:23.4-android'
-
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
 }

--- a/features/repositories/build.gradle
+++ b/features/repositories/build.gradle
@@ -10,12 +10,14 @@ android {
 dependencies {
     implementation project(':features:repository')
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
-    annotationProcessor 'com.google.auto.factory:auto-factory:1.0-beta3'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-SNAPSHOT'
+    rootProject.repos.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.unitTestsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.annotationProcessorsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
 
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
-
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
 }

--- a/features/repository/build.gradle
+++ b/features/repository/build.gradle
@@ -10,10 +10,14 @@ android {
 dependencies {
     api project(':features:base')
 
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
-    annotationProcessor 'com.google.auto.factory:auto-factory:1.0-beta3'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:9.0.0-SNAPSHOT'
+    rootProject.repository.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.unitTestsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
+    rootProject.annotationProcessorsDependencies.each { item ->
+        add(item.configuration, item.dependency, item.options)
+    }
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
 }


### PR DESCRIPTION
Instead having dependencies configurations (versions, packages) in each module separately, now everything is set in `buildsystem/dependencies.gradle`